### PR TITLE
Record forecasts with timestamps

### DIFF
--- a/src/models/dynamic_horizon_predictor.py
+++ b/src/models/dynamic_horizon_predictor.py
@@ -7,7 +7,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from scipy import stats
+<<<<<<< HEAD
 from typing import List, Dict, Optional
+=======
+from datetime import datetime
+from typing import Optional
+>>>>>>> 45a18a8 (Record forecasts with timestamps)
 
 
 class DynamicHorizonPredictor(nn.Module):
@@ -56,6 +61,9 @@ class DynamicHorizonPredictor(nn.Module):
 
         # Move layers to the specified device during initialization
         self.to(self.device)
+
+        # Track generated forecasts for later analysis
+        self.forecast_history = []
 
     def forward(self, features: torch.Tensor, requested_horizon: float = None):
         """
@@ -135,7 +143,12 @@ class DynamicHorizonPredictor(nn.Module):
         features: torch.Tensor,
         requested_horizon: int = None,
         confidence: float = 0.68,
+<<<<<<< HEAD
         history_list: Optional[List[Dict]] = None,
+=======
+        timestamp: Optional[datetime] = None,
+        history_list: Optional[list] = None,
+>>>>>>> 45a18a8 (Record forecasts with timestamps)
     ) -> dict:
         """Return a simple forecast dictionary.
 
@@ -170,14 +183,31 @@ class DynamicHorizonPredictor(nn.Module):
         low = mean - z * std
         high = mean + z * std
 
+<<<<<<< HEAD
         forecast = {
+=======
+        result = {
+>>>>>>> 45a18a8 (Record forecasts with timestamps)
             "mean": mean.squeeze().item(),
             "low": low.squeeze().item(),
             "high": high.squeeze().item(),
             "horizon": horizon,
         }
 
+<<<<<<< HEAD
         if history_list is not None:
             history_list.append(forecast)
 
         return forecast
+=======
+        # Store forecast with timestamp for external analysis
+        record = {
+            "timestamp": timestamp or datetime.utcnow(),
+            **result,
+        }
+        self.forecast_history.append(record)
+        if history_list is not None:
+            history_list.append(record.copy())
+
+        return result
+>>>>>>> 45a18a8 (Record forecasts with timestamps)

--- a/src/training/backtesting.py
+++ b/src/training/backtesting.py
@@ -1942,32 +1942,21 @@ class Backtester:
         # Record position value
         self.position_values.append(position_value)
         
-        # Locate forecast for this timestamp
-        forecast_entry = next(
-            (
-                f for f in self.forecast_history
-                if f.get('timestamp') == timestamp
-            ),
-            None,
-        )
+        # Record prediction quality if a stored forecast exists for this timestamp
+        forecast_value = None
+        for entry in self.forecast_history:
+            if entry.get('timestamp') == timestamp:
+                forecast_value = entry.get('mean')
+                break
 
-        # Only record prediction quality if a stored forecast exists
-        if forecast_entry is not None and target is not None:
-            forecast = forecast_entry.get('forecast')
-            if prediction is None:
-                if isinstance(forecast, dict) and 'mean' in forecast:
-                    prediction = forecast['mean']
-                else:
-                    prediction = forecast
-
-            if prediction is not None:
-                self.prediction_quality.append({
-                    'timestamp': timestamp,
-                    'prediction': prediction,
-                    'target': target,
-                    'error': prediction - target,
-                    'price': price
-                })
+        if forecast_value is not None and target is not None:
+            self.prediction_quality.append({
+                'timestamp': timestamp,
+                'prediction': forecast_value,
+                'target': target,
+                'error': forecast_value - target,
+                'price': price
+            })
     
     def run_backtest(self, data, signal_generator, strategy_params=None, verbose=True):
         """

--- a/tests/test_forecast_history.py
+++ b/tests/test_forecast_history.py
@@ -1,0 +1,34 @@
+import unittest
+from datetime import datetime
+import torch
+
+from src.training.forecast_helper import ForecastHelperManager
+from src.training.backtesting import Backtester
+
+
+class ForecastHistoryTest(unittest.TestCase):
+    def test_forecast_records_used_in_backtester(self):
+        helper_mgr = ForecastHelperManager()
+        backtester = Backtester()
+
+        helper_mgr.get_helper("Scalping", feature_size=1)
+        ts = datetime.utcnow()
+        features = torch.zeros(1, 1)
+        helper_mgr.forecast(
+            "Scalping",
+            features,
+            requested_horizon=1,
+            timestamp=ts,
+            backtester=backtester,
+        )
+
+        backtester.update_metrics(price=1.0, timestamp=ts, target=1.0)
+
+        self.assertTrue(
+            len(backtester.prediction_quality) > 0,
+            "prediction_quality should record entry when forecast history exists",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track each forecast in `DynamicHorizonPredictor`
- propagate recorded forecasts through `ForecastHelperManager` to the backtester
- only compute prediction quality when a forecast exists
- clean whitespace in `progressive_training`
- add test covering forecast logging

## Testing
- `pytest -q` *(fails: FileNotFoundError and other import issues)*